### PR TITLE
fix(outputDepToFile): 修复没有设置导出依赖树目录不能正常检测的bug

### DIFF
--- a/src/main/java/com/immomo/momosec/maven/plugins/MosecTest.java
+++ b/src/main/java/com/immomo/momosec/maven/plugins/MosecTest.java
@@ -146,7 +146,7 @@ public class MosecTest extends AbstractMojo {
             projectTree.addProperty("severityLevel", severityLevel);
             String jsonDepTree = new GsonBuilder().setPrettyPrinting().create().toJson(projectTree);
             getLog().debug(jsonDepTree);
-            if (!"".equals(outputDepToFile)) {
+            if (outputDepToFile!=null) {
                 writeToFile(outputDepToFile, jsonDepTree);
             }
 


### PR DESCRIPTION
当我第一次使用的使用,开启debug模式,有这个报错
[ERROR] There was a problem with the Mosec plugin.
java.lang.NullPointerException
    at java.io.File.<init> (File.java:279)
    at com.immomo.momosec.maven.plugins.Renderer.writeToFile (Renderer.java:93)
    at com.immomo.momosec.maven.plugins.MosecTest.execute (MosecTest.java:150)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)

下载源码远程调试
使用以下命令运行
 MOSEC_ENDPOINT=http://xxx.xxx.com/api/plugin \
  mvnDebug mosec:test -DonlyProvenance=true
Preparing to execute Maven in debug mode
Listening for transport dt_socket at address: 8000
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------< com.immomo.momosec:mosec-maven-plugin >----------------
[INFO] Building Mosec Maven Plugin 1.0.7
[INFO] ----------------------------[ maven-plugin ]----------------------------
[INFO] 
[INFO] --- mosec-maven-plugin:1.0.7:test (default-cli) @ mosec-maven-plugin ---



调试器显示 outputDepToFile=null

![Screenshot from 2021-04-07 14-35-09](https://user-images.githubusercontent.com/6567984/113821426-a8618880-97ae-11eb-8d00-a9fd507ddb30.png)



